### PR TITLE
implement chat_bot bloc and dependency injection

### DIFF
--- a/hakim_hub_mobile/lib/features/chatbot/presentation/bloc/chat_bot_bloc.dart
+++ b/hakim_hub_mobile/lib/features/chatbot/presentation/bloc/chat_bot_bloc.dart
@@ -1,0 +1,34 @@
+import 'package:dartz/dartz.dart';
+import 'package:equatable/equatable.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:hakim_hub_mobile/features/chatbot/domain/usecases/get_chat_response.dart';
+import '../../../../core/error/failures.dart';
+import 'package:hakim_hub_mobile/features/chatbot/domain/entities/chat_response_entity.dart';
+
+import '../../domain/entities/chat_request_entity.dart';
+part 'chat_bot_state.dart';
+part 'chat_bot_event.dart';
+
+class ChatBotBloc extends Bloc<ChatBotEvent, ChatBotState> {
+  final GetChatResponse getChatResponse;
+  ChatBotBloc({required this.getChatResponse}) : super(ChatBotInitialState()) {
+    on<GetChatResponseEvent>(
+      (event, emit) {},
+    );
+  }
+
+  ChatBotState chatResponseSuccessOrFailure(
+      Either<Failure, ChatResponse> data) {
+    return data.fold(
+      (error) => ChatBotFailureState(error: error),
+      (success) => ChatBotSuccessState(chatResponse: success),
+    );
+  }
+
+  void _getChatResponse(
+      GetChatResponseEvent event, Emitter<ChatBotState> emit) async {
+    emit(ChatBotLoadingState());
+    final result = await getChatResponse(event.request);
+    emit(chatResponseSuccessOrFailure(result));
+  }
+}

--- a/hakim_hub_mobile/lib/features/chatbot/presentation/bloc/chat_bot_event.dart
+++ b/hakim_hub_mobile/lib/features/chatbot/presentation/bloc/chat_bot_event.dart
@@ -1,0 +1,14 @@
+part of 'chat_bot_bloc.dart';
+
+abstract class ChatBotEvent extends Equatable {
+  @override
+  List<Object?> get props => [];
+}
+
+class GetChatResponseEvent extends ChatBotEvent {
+  final ChatRequest request;
+  GetChatResponseEvent({required this.request});
+
+  @override
+  List<Object?> get props => [request];
+}

--- a/hakim_hub_mobile/lib/features/chatbot/presentation/bloc/chat_bot_state.dart
+++ b/hakim_hub_mobile/lib/features/chatbot/presentation/bloc/chat_bot_state.dart
@@ -1,0 +1,28 @@
+part of 'chat_bot_bloc.dart';
+
+abstract class ChatBotState extends Equatable {
+  const ChatBotState();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class ChatBotInitialState extends ChatBotState {}
+
+class ChatBotLoadingState extends ChatBotState {}
+
+class ChatBotSuccessState extends ChatBotState {
+  final ChatResponse chatResponse;
+  const ChatBotSuccessState({required this.chatResponse});
+
+  @override
+  List<Object?> get props => [chatResponse];
+}
+
+class ChatBotFailureState extends ChatBotState {
+  final Failure error;
+  const ChatBotFailureState({required this.error});
+
+  @override
+  List<Object?> get props => [error];
+}

--- a/hakim_hub_mobile/lib/features/chatbot/presentation/screen/chat_page.dart
+++ b/hakim_hub_mobile/lib/features/chatbot/presentation/screen/chat_page.dart
@@ -1,10 +1,8 @@
 import 'package:flutter/material.dart';
-import 'package:http/http.dart' as http;
 import 'package:responsive_sizer/responsive_sizer.dart';
 import '../../../../core/utils/colors.dart';
-import '../../../../core/utils/icons.dart';
+
 import '../../../../core/utils/pixle_to_percent.dart';
-import '../../../../core/utils/ui_converter.dart';
 
 class ChatPage extends StatefulWidget {
   @override

--- a/hakim_hub_mobile/lib/features/hospital/presentation/bloc/bloc/hospital_detail_bloc.dart
+++ b/hakim_hub_mobile/lib/features/hospital/presentation/bloc/bloc/hospital_detail_bloc.dart
@@ -18,6 +18,7 @@ class HospitalDetailBloc
 
   HospitalDetailBloc({required this.getDoctorByFilter,required this.getHospitalDetail})
       : super(HospitalDetailInitial()) {
+        
     on<HospitalDetailEvent>((event, emit) {});
 
     on<HospitalDetailGetEvent>((event, emit) async {

--- a/hakim_hub_mobile/lib/injection/chat_bot_injection.dart
+++ b/hakim_hub_mobile/lib/injection/chat_bot_injection.dart
@@ -1,0 +1,38 @@
+import 'package:get_it/get_it.dart';
+import 'package:hakim_hub_mobile/features/chatbot/data/datasources/chat_remote_data_soure.dart';
+import 'package:hakim_hub_mobile/features/chatbot/domain/repositories/chat_repository.dart';
+import 'package:hakim_hub_mobile/features/chatbot/domain/usecases/get_chat_response.dart';
+import 'package:hakim_hub_mobile/features/chatbot/presentation/bloc/chat_bot_bloc.dart';
+
+
+import '../features/chatbot/data/repositories/chat_repository_impl.dart';
+
+Future<void> chatBotInit(GetIt sl) async {
+  // Bloc
+  sl.registerFactory(
+    () => ChatBotBloc(
+      getChatResponse: sl(),
+    ),
+  );
+
+  // usecases
+  sl.registerLazySingleton(
+    () => GetChatResponse(
+      repository: sl(),
+    ),
+  );
+
+  // Repositories
+  sl.registerLazySingleton<ChatRepository>(
+    () => ChatRepositoryImpl(
+      remoteDataSource: sl(),
+    ),
+  );
+
+  // Data Sources
+  sl.registerLazySingleton<ChatRemoteDataSource>(
+    () => ChatRemoteDataSourceImpl(
+      client: sl(),
+    ),
+  );
+}

--- a/hakim_hub_mobile/lib/injection/injection.dart
+++ b/hakim_hub_mobile/lib/injection/injection.dart
@@ -1,15 +1,16 @@
-
 import 'package:get_it/get_it.dart';
-
 
 import 'package:hakim_hub_mobile/injection/search_hospitals_injection.dart';
 
+import 'chat_bot_injection.dart';
 import 'doctor_detail_injection.dart';
 import 'hospital_detail_injection.dart';
+
 final sl = GetIt.instance;
 
 Future<void> init() async {
   await searchHospitalsinit(sl);
   await doctorDetailInit(sl);
   await hospitalDetailsinit(sl);
+  await chatBotInit(sl);
 }

--- a/hakim_hub_mobile/lib/main.dart
+++ b/hakim_hub_mobile/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:hakim_hub_mobile/features/chatbot/presentation/bloc/chat_bot_bloc.dart';
 import 'package:hakim_hub_mobile/features/core/splash_screen.dart';
 import 'package:hakim_hub_mobile/router/main_router.dart';
 import 'package:responsive_sizer/responsive_sizer.dart';
@@ -35,6 +36,9 @@ class MyApp extends StatelessWidget {
           ),
           BlocProvider<HospitalDetailBloc>(
             create: (context) => injection.sl<HospitalDetailBloc>(),
+          ),
+          BlocProvider<ChatBotBloc>(
+            create: (context) => injection.sl<ChatBotBloc>(),
           ),
         ], child: RouterMain());
       },


### PR DESCRIPTION
This pr adds bloc and dependency injection for chatbot feature. 

changes made:
- Implementing the ChatBotBloc class to handle the business logic and state management of the ChatBot feature.
- Defining the necessary events and states using the `flutter_bloc` package.
- Integrating the `dartz` package for handling functional programming concepts such as Either, which helps manage success and failure scenarios.
- Adding the GetChatResponse use case to fetch responses from the chatbot API.
- Creating the ChatRequestEntity and ChatResponseEntity to represent the request and response data structures.
